### PR TITLE
Remove options menu

### DIFF
--- a/extended_weapons_mod/data/forms/mainmenu.form
+++ b/extended_weapons_mod/data/forms/mainmenu.form
@@ -33,18 +33,19 @@
         <size width="300" height="32"/>
         <font>smalfont</font>
       </textbutton>
-      <textbutton id="BUTTON_OPTIONS" text="Options">
+      <!-- Options menu commented out until useful -->
+      <!-- <textbutton id="BUTTON_OPTIONS" text="Options">
+        <position x="centre" y="500"/>
+        <size width="300" height="32"/>
+        <font>smalfont</font>
+      </textbutton> -->
+      <textbutton id="BUTTON_QUIT" text="Quit">
         <position x="centre" y="500"/>
         <size width="300" height="32"/>
         <font>smalfont</font>
       </textbutton>
-      <textbutton id="BUTTON_QUIT" text="Quit">
-        <position x="centre" y="550"/>
-        <size width="300" height="32"/>
-        <font>smalfont</font>
-      </textbutton>
       <textbutton id="BUTTON_DEBUG" text="Debug Menu" visible="N">
-        <position x="centre" y="600"/>
+        <position x="centre" y="550"/>
         <size width="300" height="32"/>
         <font>smalfont</font>
       </textbutton>


### PR DESCRIPTION
I noticed that the worthless options menu is still present in the mod, it doesn't do anything when clicked. Figured it should follow the main menu of the unmodded game.